### PR TITLE
Fix relative path & hard-code script path

### DIFF
--- a/scripts/functools.sh
+++ b/scripts/functools.sh
@@ -1,0 +1,55 @@
+#===  FUNCTION  ================================================================
+#         NAME:  usage
+#  DESCRIPTION:  Display usage information.
+#===============================================================================
+function usage ()
+{
+    echo "Usage :  $0 [options] [--]
+
+    Options:
+    -h|help       Display this message
+    -j|jpf_path <jpf_path>   Set jpf_path
+    "
+
+}    # ----------  end of function usage  ----------
+
+#-----------------------------------------------------------------------
+#  Handle command line arguments
+#-----------------------------------------------------------------------
+
+while getopts ":j:h" opt
+do
+  case $opt in
+
+    h|help     )  usage; exit 0   ;;
+
+    j|jpf_path  )  JPF_DIR="$OPTARG";  ;;
+
+    * )  echo -e "\n  Option does not exist : $OPTARG\n"
+                usage; exit 1   ;;
+
+  esac    # --- end of case ---
+done
+shift $((OPTIND-1))
+
+
+JR_DIR=$FILEDIR/../
+
+if [ -z $JPF_DIR ]; then
+    JPF_DIR=$FILEDIR/../../jpf-core/
+    echo "Automatically set JPF_DIR=$JPF_DIR"
+fi
+
+if [ ! -e $JPF_DIR  ]; then
+    echo "'JPF_DIR=$JPF_DIR' does not exists"
+    exit 1
+fi
+
+
+
+# TODO:
+# 1. The code could be organized in a better way.
+# 2. Shell is not a good language to organize and reuse code. Some Python CLI tools(e.g. fire) could organize the scripts in a better way
+# 3. The scripts could be more automatic(e.g. use `~/.jpf/site.properties` to set the path automatically).  But using shell script to
+#    implement it will be too complicated. It will be much better to use Python to implement it.
+# 4. A scripts management framework will reduce the scripts maintenance cost.

--- a/scripts/runCoverageTCAS.sh
+++ b/scripts/runCoverageTCAS.sh
@@ -3,27 +3,33 @@
 
 #no input is provided, the number o steps are hardcoded
 
+# Leverage the path of scripts to locate project path automatically
+if [ $0 = "-bash" -o $0 = "-zsh" -o $0 = "zsh"  ]; then
+    FILEDIR=`pwd`
+else
+    FILEDIR="$( cd "$(dirname $(readlink -f "$0"))" ; pwd -P )"
+fi
 
-alias runCoverage='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/media/soha/DATA/git/jrTCG/lib TARGET_CLASSPATH_WALA=/media/soha/DATA/git/jrTCG/build/examples/ java -Djava.library.path=/media/soha/DATA/git/jrTCG/lib  -ea -Xmx5000m -Dfile.encoding=UTF-8 -jar /home/soha/git/jpf-core/build/RunJPF.jar '
+source $FILEDIR/functools.sh
+
+
+alias runCoverage='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JR_DIR/lib TARGET_CLASSPATH_WALA=$JR_DIR/build/examples/ java -Djava.library.path=$JR_DIR/lib  -ea -Xmx5000m -Dfile.encoding=UTF-8 -jar $JPF_DIR/build/RunJPF.jar '
 
 
 shopt -s expand_aliases
 
-
-COVERAGEDIR=/media/soha/DATA/git/jrTCG
-
-MAX_STEPS=10 && export MAX_STEPS
+export MAX_STEPS=10
 
 echo "maxsteps is $MAX_STEPS"
 
-mkdir $COVERAGEDIR/logs/log_tacas
+mkdir -p $JR_DIR/logs/log_tacas
 
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASCollect.jpf >& $COVERAGEDIR/logs/log_tacas/TCASCollect_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Prune.jpf >& $COVERAGEDIR/logs/log_tacas/TCASCollect_Prune_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Guide.jpf >& $COVERAGEDIR/logs/log_tacas/TCASCollect_Guide_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Prune_Guide.jpf >& $COVERAGEDIR/logs/log_tacas/TCASCollect_Prune_Guide_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASCollect.jpf >& $JR_DIR/logs/log_tacas/TCASCollect_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Prune.jpf >& $JR_DIR/logs/log_tacas/TCASCollect_Prune_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Guide.jpf >& $JR_DIR/logs/log_tacas/TCASCollect_Guide_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/tcas/TCASCollect_Prune_Guide.jpf >& $JR_DIR/logs/log_tacas/TCASCollect_Prune_Guide_steps$MAX_STEPS.log
 
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode2.jpf >& $COVERAGEDIR/logs/log_tacas/TCAS_JR_Collect.mode2_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode3.jpf >& $COVERAGEDIR/logs/log_tacas/TCAS_JR_Collect.mode3_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode4.jpf >& $COVERAGEDIR/logs/log_tacas/TCAS_JR_Collect.mode4_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode5.jpf >& $COVERAGEDIR/logs/log_tacas/TCAS_JR_Collect.mode5_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode2.jpf >& $JR_DIR/logs/log_tacas/TCAS_JR_Collect.mode2_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode3.jpf >& $JR_DIR/logs/log_tacas/TCAS_JR_Collect.mode3_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode4.jpf >& $JR_DIR/logs/log_tacas/TCAS_JR_Collect.mode4_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/tcas/TCASJR_Collect.mode5.jpf >& $JR_DIR/logs/log_tacas/TCAS_JR_Collect.mode5_steps$MAX_STEPS.log

--- a/scripts/runCoverageWBS.sh
+++ b/scripts/runCoverageWBS.sh
@@ -3,29 +3,37 @@
 #no input is provided, the number o steps are hardcoded
 
 
-alias runCoverage='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/media/soha/DATA/git/jrTCG/lib TARGET_CLASSPATH_WALA=/media/soha/DATA/git/jrTCG/build/examples/ java -Djava.library.path=/media/soha/DATA/git/jrTCG/lib  -ea -Xmx5000m -Dfile.encoding=UTF-8 -jar /home/soha/git/jpf-core/build/RunJPF.jar '
+# Leverage the path of scripts to locate project path automatically
+if [ $0 = "-bash" -o $0 = "-zsh" -o $0 = "zsh"  ]; then
+    FILEDIR=`pwd`
+else
+    FILEDIR="$( cd "$(dirname $(readlink -f "$0"))" ; pwd -P )"
+fi
+
+source $FILEDIR/functools.sh
+
+
+alias runCoverage='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JR_DIR/lib TARGET_CLASSPATH_WALA=$JR_DIR/build/examples/ java -Djava.library.path=$JR_DIR/lib  -ea -Xmx5000m -Dfile.encoding=UTF-8 -jar $JPF_DIR/build/RunJPF.jar '
 
 
 shopt -s expand_aliases
 
-
-COVERAGEDIR=/media/soha/DATA/git/jrTCG
-
-MAX_STEPS=5 && export MAX_STEPS
+export MAX_STEPS=5
 
 echo "maxsteps is $MAX_STEPS"
 
-mkdir $COVERAGEDIR/logs/log_wbs
+mkdir -p $JR_DIR/logs/log_wbs
 
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSCollect.jpf >& $COVERAGEDIR/logs/log_wbs/WBSCollect_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Prune.jpf >& $COVERAGEDIR/logs/log_wbs/WBSCollect_Prune_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Guide.jpf >& $COVERAGEDIR/logs/log_wbs/WBSCollect_Guide_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Prune_Guide.jpf >& $COVERAGEDIR/logs/log_wbs/WBSCollect_Prune_Guide_steps$MAX_STEPS.log
 
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode2.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect.mode2_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode3.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect.mode3_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode4.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect.mode4_steps$MAX_STEPS.log
-runCoverage $COVERAGEDIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode5.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect.mode5_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Prune.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect_Prune_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Guide.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect_Guide_steps$MAX_STEPS.log
-#runCoverage $COVERAGEDIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Prune_Guide.jpf >& $COVERAGEDIR/logs/log_wbs/WBS_JR_Collect_Prune_Guide_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSCollect.jpf >& $JR_DIR/logs/log_wbs/WBSCollect_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Prune.jpf >& $JR_DIR/logs/log_wbs/WBSCollect_Prune_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Guide.jpf >& $JR_DIR/logs/log_wbs/WBSCollect_Guide_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBSCollect_Prune_Guide.jpf >& $JR_DIR/logs/log_wbs/WBSCollect_Prune_Guide_steps$MAX_STEPS.log
+
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode2.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect.mode2_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode3.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect.mode3_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode4.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect.mode4_steps$MAX_STEPS.log
+runCoverage $JR_DIR/src/examples/tcgbenchmarks/runconfig/wbs/WBSJR_Collect.mode5.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect.mode5_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Prune.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect_Prune_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Guide.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect_Guide_steps$MAX_STEPS.log
+#runCoverage $JR_DIR/src/examples/veritesting/test_case_gen/wbs/WBS_JR_Collect_Prune_Guide.jpf >& $JR_DIR/logs/log_wbs/WBS_JR_Collect_Prune_Guide_steps$MAX_STEPS.log

--- a/src/main/gov/nasa/jpf/symbc/BranchListener.java
+++ b/src/main/gov/nasa/jpf/symbc/BranchListener.java
@@ -57,6 +57,7 @@ public class BranchListener extends PropertyListenerAdapter implements Publisher
 
     protected static Long startTime = System.currentTimeMillis() / 1000;
     protected static int timeForExperiment = 180 * 60; //minutes * seconds -- set to 0 if you want to run indefinitely.
+    protected String exclusionFilePath;
 
     public BranchListener(Config conf, JPF jpf) {
         jpf.addPublisherExtension(ConsolePublisher.class, this);
@@ -75,6 +76,9 @@ public class BranchListener extends PropertyListenerAdapter implements Publisher
         }
 
         if (conf.hasValue("coverageExclusions")) coverageExclusions = conf.getStringSet("coverageExclusions");
+        // Instead of setting a relative path, using configure to set the path will make it possible to run it in any
+        // directories
+        exclusionFilePath = conf.getString("jpf-symbc") + "/coverageExclusions.txt";
 
         if (conf.hasValue("symbolic.dp")) solver = conf.getString("symbolic.dp");
 
@@ -125,7 +129,7 @@ public class BranchListener extends PropertyListenerAdapter implements Publisher
         try {
             if (firstTime) {
                 System.out.println("---- CoverageMode = " + coverageMode + ", solver = " + solver + ", benchmark= " + benchmarkName + (System.getenv("MAX_STEPS") != null ? ", STEPS " + System.getenv("MAX_STEPS") : ""));
-                BranchCoverage.createObligations(ti);
+                BranchCoverage.createObligations(ti, this.exclusionFilePath);
                 ObligationMgr.finishedCollection();
                 BranchCoverage.finishedCollection();
                 firstTime = false;

--- a/src/main/gov/nasa/jpf/symbc/VeriBranchListener.java
+++ b/src/main/gov/nasa/jpf/symbc/VeriBranchListener.java
@@ -92,7 +92,7 @@ public class VeriBranchListener extends BranchListener {
         try {
             if (firstTime) {
                 System.out.println("---- CoverageMode = " + coverageMode + ", solver = " + solver + ", benchmark= " + benchmarkName + (System.getenv("MAX_STEPS") != null ? ", STEPS " + System.getenv("MAX_STEPS") : ""));
-                BranchCoverage.createObligations(ti);
+                BranchCoverage.createObligations(ti, this.exclusionFilePath);
                 ObligationMgr.finishedCollection();
                 BranchCoverage.finishedCollection();
                 firstTime = false;

--- a/src/main/gov/nasa/jpf/symbc/branchcoverage/BranchCoverage.java
+++ b/src/main/gov/nasa/jpf/symbc/branchcoverage/BranchCoverage.java
@@ -28,9 +28,9 @@ public class BranchCoverage {
     public static CallGraph cg;
 
 
-    public static void createObligations(ThreadInfo ti) throws WalaException, IOException, CallGraphBuilderCancelException {
+    public static void createObligations(ThreadInfo ti, String exclusionFilePath) throws WalaException, IOException, CallGraphBuilderCancelException {
 
-        File exclusionFile = new File("../coverageExclusions.txt");
+        File exclusionFile = new File(exclusionFilePath);
 
         String classPath = targetAbsPath.substring(0, targetAbsPath.lastIndexOf("/"));
         AnalysisScope scope = AnalysisScopeReader.makeJavaBinaryAnalysisScope(classPath, exclusionFile);


### PR DESCRIPTION
Hi,
Fix the following issues.
1.  Instead of using a relative path, using configure to set the path will make it possible to run it in any directories 
2. Optimize the running scripts to make anyone run them without modifying the script. 
This is related to my GSOC proposal Goal 2

Thanks.