### PR TITLE
fix: implement Java-based Math.toRadians and Math.toDegrees for symbolic tracking

### DIFF
--- a/LICENSE-2.0.txt
+++ b/LICENSE-2.0.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 Soha Hussein, Vaibhav Sharma, Mike Whalen, Stephen McCamant, and Willem Visser
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,3 +200,28 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
+    Java Ranger uses other dependencies for either analyzing the bytecode, for verifying properties, or for utilizing
+    different solvers. These dependencies uses the following licenses:
+    aima (https://github.com/aimacode/aima-java) => MIT License
+    asm (https://asm.ow2.io/) => BSD-3-Clause
+    dk.brics.automaton (https://github.com/cs-au-dk/dk.brics.automaton) => BSD license.
+    bcel (https://commons.apache.org/proper/commons-bcel/) => Apache License 2.0
+    choco (https://github.com/chocoteam/choco-solver) => BSD 4-Clause License
+    wala (https://github.com/wala/WALA) =>  Eclipse Public License 2.0
+    z3 (https://github.com/Z3Prover/z3)=> MIT License
+    apache commons (https://github.com/apache/commons-lang/blob/master/LICENSE.txt) => Apache License 2.0
+    coral (https://github.com/psycopaths/jconstraints-coral) => Apache License 2.0
+    grappa (https://github.com/uwsampa/grappa) => BSD-3-Clause License
+    green => GNU Lesser General Public License v3.0
+    iasolver (https://www.cs.brandeis.edu/~tim/Applets/IAsolver.html) => GNU General Public License
+    jedis-2 (https://github.com/redis/jedis) => MIT License
+    jkind (https://github.com/loonwerks/jkind) => BSD 3-Clause "New" or "Revised" License
+    JSAP-2 (https://github.com/martylamb/jsap) => Apache License 2.0
+    cvc3 (https://cs.nyu.edu/acsys/cvc3/) => BSD licence
+    gmp (https://gmplib.org/) => GNU General Public License version 3 or more, or GNU Lesser General Public License version 3 or more
+    opt4j (https://github.com/sdarg/opt4j/) => MIT license
+    hamcrest (https://github.com/hamcrest/JavaHamcrest) => BSD license.
+    sat4j (https://gitlab.ow2.org/sat4j/sat4j) => Eclipse Public License Version 1.0, GNU General Public License version 3 or more, or GNU Lesser General Public License version 3 or more
+    fasterxml (https://github.com/FasterXML/jackson-core) => Apache License 2.0
+    proteus (https://github.com/noboomu/proteus) =>  Apache-2.0 License
+    yices (https://github.com/SRI-CSL/yices2) => GNU GENERAL PUBLIC LICENSE

--- a/README.md
+++ b/README.md
@@ -33,4 +33,3 @@ The following people have contributed to Java Ranger
 3. Michael Whalen
 4. Stephen McCamant
 5. Willem Visser
-

--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ The following people have contributed to Java Ranger
 3. Michael Whalen
 4. Stephen McCamant
 5. Willem Visser
+


### PR DESCRIPTION
## Why is this pull request needed?
#22 
Switched from native to a java implementation in Math.java
## Test results:
Local test for reproducing the bug:
```Java
package gov.nasa.jpf.symbc;

public class RadiansTest {
  public static void test(double degrees) { 
    double rad = Math.toRadians(degrees);
    if (rad > 1.0) {
      System.out.println(">> Path: rad > 1.0");
    } else {
      System.out.println(">> Path: rad <= 1.0");
    }
  }

  public static void main (String[] args) {
    test(0.0); 
  }
}
```
Note: 0.0 was used here as a concrete value for testing.
```
salmane@salmane-VivoBook-ASUSLaptop-X515EP-X515EP:~/Desktop/OSS/pathfinder/jpf-symbc$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
java -jar ../jpf-core/build/RunJPF.jar +site=jpf.properties src/examples/RadiansTest.jpf
Mixed symbolic/concrete execution ...
Running Symbolic PathFinder ...
symbolic.dp=z3
symbolic.string_dp_timeout_ms=0
symbolic.string_dp=none
symbolic.max_pc_length=2147483647
symbolic.max_pc_msec=0
symbolic.bvlength=32
symbolic.min_int=-2147483648
symbolic.min_long=-9223372036854775808
symbolic.min_short=-32768
symbolic.min_byte=-128
symbolic.min_char=0
symbolic.max_int=2147483647
symbolic.max_long=9223372036854775807
symbolic.max_short=32767
symbolic.max_byte=127
symbolic.max_char=65535
symbolic.min_double=4.9E-324
symbolic.max_double=1.7976931348623157E308
JavaPathfinder core system v8.0 - (C) 2005-2014 United States Government. All rights reserved.


====================================================== system under test
gov.nasa.jpf.symbc.RadiansTest.main()

====================================================== search started: 1/20/26 4:12 PM
numeric PC: constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) < CONST_1.0 -> true

### PCs: total:1 sat:1 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) < CONST_1.0
numeric PC: constraint # = 1
CONST_1.0 == ((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) -> true

### PCs: total:2 sat:2 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
CONST_1.0 == ((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793)
numeric PC: constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) > CONST_1.0 -> true

### PCs: total:3 sat:3 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) > CONST_1.0
>> Path: rad <= 1.0
>> Path: rad <= 1.0
>> Path: rad > 1.0

====================================================== results
no errors detected

====================================================== statistics
elapsed time:       00:00:00
states:             new=4,visited=0,backtracked=4,end=3
search:             maxDepth=2,constraints=0
choice generators:  thread=1 (signal=0,lock=1,sharedRef=0,threadApi=0,reschedule=0), data=1
heap:               new=357,released=29,maxLive=349,gcCycles=4
instructions:       3258
max memory:         115MB
loaded code:        classes=60,methods=1297

====================================================== search finished: 1/20/26 4:12 PM
```
From the states, you can see that 4 branches were explored
