### PR TITLE
fix: implement Java-based Math.toRadians and Math.toDegrees for symbolic tracking

### DIFF
--- a/jpf-symbc/src/classes/java/lang/Math.java
+++ b/jpf-symbc/src/classes/java/lang/Math.java
@@ -161,5 +161,12 @@ public class Math {
 	  public native static double pow ( double a, double b);
 
 	  public static native double log10(double a);
+	  
+	  public static double toRadians(double angdeg) {
+		    return angdeg / 180.0 * PI;
+	  }
+	  public static double toDegrees(double angrad) {
+		    return angrad * 180.0 / PI;
+	  }	 
 
 }


### PR DESCRIPTION
## Why is this pull request needed?
#22 
Switched from native to a java implementation in Math.java
## Test results:
Local test for reproducing the bug:
```Java
package gov.nasa.jpf.symbc;

public class RadiansTest {
  public static void test(double degrees) { 
    double rad = Math.toRadians(degrees);
    if (rad > 1.0) {
      System.out.println(">> Path: rad > 1.0");
    } else {
      System.out.println(">> Path: rad <= 1.0");
    }
  }

  public static void main (String[] args) {
    test(0.0); 
  }
}
```
Note: 0.0 was used here as a concrete value for testing.
```
salmane@salmane-VivoBook-ASUSLaptop-X515EP-X515EP:~/Desktop/OSS/pathfinder/jpf-symbc$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib
java -jar ../jpf-core/build/RunJPF.jar +site=jpf.properties src/examples/RadiansTest.jpf
Mixed symbolic/concrete execution ...
Running Symbolic PathFinder ...
symbolic.dp=z3
symbolic.string_dp_timeout_ms=0
symbolic.string_dp=none
symbolic.max_pc_length=2147483647
symbolic.max_pc_msec=0
symbolic.bvlength=32
symbolic.min_int=-2147483648
symbolic.min_long=-9223372036854775808
symbolic.min_short=-32768
symbolic.min_byte=-128
symbolic.min_char=0
symbolic.max_int=2147483647
symbolic.max_long=9223372036854775807
symbolic.max_short=32767
symbolic.max_byte=127
symbolic.max_char=65535
symbolic.min_double=4.9E-324
symbolic.max_double=1.7976931348623157E308
JavaPathfinder core system v8.0 - (C) 2005-2014 United States Government. All rights reserved.


====================================================== system under test
gov.nasa.jpf.symbc.RadiansTest.main()

====================================================== search started: 1/20/26 4:12 PM
numeric PC: constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) < CONST_1.0 -> true

### PCs: total:1 sat:1 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) < CONST_1.0
numeric PC: constraint # = 1
CONST_1.0 == ((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) -> true

### PCs: total:2 sat:2 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
CONST_1.0 == ((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793)
numeric PC: constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) > CONST_1.0 -> true

### PCs: total:3 sat:3 unsat:0

string analysis: SPC # = 0
NPC constraint # = 1
((degrees_1_SYMREAL / CONST_180.0) * CONST_3.141592653589793) > CONST_1.0
>> Path: rad <= 1.0
>> Path: rad <= 1.0
>> Path: rad > 1.0

====================================================== results
no errors detected

====================================================== statistics
elapsed time:       00:00:00
states:             new=4,visited=0,backtracked=4,end=3
search:             maxDepth=2,constraints=0
choice generators:  thread=1 (signal=0,lock=1,sharedRef=0,threadApi=0,reschedule=0), data=1
heap:               new=357,released=29,maxLive=349,gcCycles=4
instructions:       3258
max memory:         115MB
loaded code:        classes=60,methods=1297

====================================================== search finished: 1/20/26 4:12 PM
```
From the states, you can see that 4 branches were explored
