### PR TITLE
feat(fp): implement IEEE‑754 special value constants (Issue #27)

### DIFF
--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/FpSort.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/FpSort.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpf.symbc.numeric;
+
+/**
+ * Distinguishes between single and double precision floating‑point sorts.
+ */
+public enum FpSort {
+    FLOAT,   // 32‑bit, 8 exponent bits, 24 significand bits
+    DOUBLE;  // 64‑bit, 11 exponent bits, 53 significand bits
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealInfinity.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealInfinity.java
@@ -1,0 +1,43 @@
+package gov.nasa.jpf.symbc.numeric;
+
+import gov.nasa.jpf.symbc.numeric.ConstraintExpressionVisitor;
+
+public class RealInfinity extends RealSpecialConstant {
+    private final boolean positive;
+
+    public static RealInfinity get(boolean positive, FpSort sort) {
+        return new RealInfinity(positive, sort);
+    }
+
+    private RealInfinity(boolean positive, FpSort sort) {
+        super(positive ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY, sort);
+        this.positive = positive;
+    }
+
+    public boolean isPositive() {
+        return positive;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RealInfinity)) return false;
+        RealInfinity other = (RealInfinity) obj;
+        return this.positive == other.positive && this.sort == other.sort;
+    }
+
+    @Override
+    public int hashCode() {
+        return (positive ? 1 : 0) * 31 + sort.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        String sign = positive ? "+" : "-";
+        return (sort == FpSort.FLOAT ? "Float" : "Double") + sign + "Inf";
+    }
+
+    @Override
+    public void accept(ConstraintExpressionVisitor visitor) {
+        visitor.postVisit((RealConstant) this);
+    }
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealNaN.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealNaN.java
@@ -1,0 +1,32 @@
+package gov.nasa.jpf.symbc.numeric;
+
+import gov.nasa.jpf.symbc.numeric.ConstraintExpressionVisitor;
+
+public class RealNaN extends RealSpecialConstant {
+    public static final RealNaN FLOAT_NAN = new RealNaN(FpSort.FLOAT);
+    public static final RealNaN DOUBLE_NAN = new RealNaN(FpSort.DOUBLE);
+
+    private RealNaN(FpSort sort) {
+        super(Double.NaN, sort);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof RealNaN && ((RealNaN) obj).sort == this.sort;
+    }
+
+    @Override
+    public int hashCode() {
+        return sort.hashCode() * 31;
+    }
+
+    @Override
+    public String toString() {
+        return sort == FpSort.FLOAT ? "FloatNaN" : "DoubleNaN";
+    }
+
+    @Override
+    public void accept(ConstraintExpressionVisitor visitor) {
+        visitor.postVisit((RealConstant) this);
+    }
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealSpecialConstant.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealSpecialConstant.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpf.symbc.numeric;
+
+/**
+ * Base class for all IEEE‑754 special values (NaN, infinities, signed zero).
+ * Stores the precision sort (float/double) to enable correct SMT‑LIB translation later.
+ */
+public abstract class RealSpecialConstant extends RealConstant {
+    protected final FpSort sort;
+
+    public RealSpecialConstant(double value, FpSort sort) {
+        super(value);
+        this.sort = sort;
+    }
+
+    public FpSort getSort() {
+        return sort;
+    }
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealZero.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/RealZero.java
@@ -1,0 +1,43 @@
+package gov.nasa.jpf.symbc.numeric;
+
+import gov.nasa.jpf.symbc.numeric.ConstraintExpressionVisitor;
+
+public class RealZero extends RealSpecialConstant {
+    private final boolean positive;
+
+    public static RealZero get(boolean positive, FpSort sort) {
+        return new RealZero(positive, sort);
+    }
+
+    private RealZero(boolean positive, FpSort sort) {
+        super(positive ? 0.0 : Double.longBitsToDouble(0x8000000000000000L), sort);
+        this.positive = positive;
+    }
+
+    public boolean isPositive() {
+        return positive;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RealZero)) return false;
+        RealZero other = (RealZero) obj;
+        return this.positive == other.positive && this.sort == other.sort;
+    }
+
+    @Override
+    public int hashCode() {
+        return (positive ? 2 : 3) * 31 + sort.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        String sign = positive ? "+" : "-";
+        return (sort == FpSort.FLOAT ? "Float" : "Double") + sign + "Zero";
+    }
+
+    @Override
+    public void accept(ConstraintExpressionVisitor visitor) {
+        visitor.postVisit((RealConstant) this);
+    }
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SpecialValueFactory.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/SpecialValueFactory.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpf.symbc.numeric;
+
+/**
+ * Helper for bytecode instructions to produce special value constants.
+ */
+public class SpecialValueFactory {
+    public static RealNaN createNaN(boolean isDouble) {
+        return isDouble ? RealNaN.DOUBLE_NAN : RealNaN.FLOAT_NAN;
+    }
+
+    public static RealInfinity createInfinity(boolean positive, boolean isDouble) {
+        return RealInfinity.get(positive, isDouble ? FpSort.DOUBLE : FpSort.FLOAT);
+    }
+
+    public static RealZero createZero(boolean positive, boolean isDouble) {
+        return RealZero.get(positive, isDouble ? FpSort.DOUBLE : FpSort.FLOAT);
+    }
+}

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/veritesting/ast/visitors/ExprVisitor.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/veritesting/ast/visitors/ExprVisitor.java
@@ -1,6 +1,9 @@
 package gov.nasa.jpf.symbc.veritesting.ast.visitors;
 
 
+import gov.nasa.jpf.symbc.numeric.RealInfinity;
+import gov.nasa.jpf.symbc.numeric.RealNaN;
+import gov.nasa.jpf.symbc.numeric.RealZero;
 import gov.nasa.jpf.symbc.veritesting.ast.def.*;
 import za.ac.sun.cs.green.expr.*;
 

--- a/jpf-symbc/src/tests/gov/nasa/jpf/symbc/numeric/TestSpecialValue.java
+++ b/jpf-symbc/src/tests/gov/nasa/jpf/symbc/numeric/TestSpecialValue.java
@@ -1,0 +1,215 @@
+package gov.nasa.jpf.symbc.numeric;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestSpecialValue {
+
+    // RealNaN tests
+
+    @Test
+    public void testNaNInstances() {
+        assertNotNull(RealNaN.FLOAT_NAN);
+        assertNotNull(RealNaN.DOUBLE_NAN);
+        assertNotSame(RealNaN.FLOAT_NAN, RealNaN.DOUBLE_NAN);
+    }
+
+    @Test
+    public void testNaNEquality() {
+        RealNaN floatNaN1 = RealNaN.FLOAT_NAN;
+        RealNaN floatNaN2 = RealNaN.FLOAT_NAN;
+        RealNaN doubleNaN = RealNaN.DOUBLE_NAN;
+
+        assertEquals(floatNaN1, floatNaN2);
+        assertNotEquals(floatNaN1, doubleNaN);
+        assertEquals(floatNaN1.hashCode(), floatNaN2.hashCode());
+        assertNotEquals(floatNaN1.hashCode(), doubleNaN.hashCode());
+    }
+
+    @Test
+    public void testNaNToString() {
+        assertEquals("FloatNaN", RealNaN.FLOAT_NAN.toString());
+        assertEquals("DoubleNaN", RealNaN.DOUBLE_NAN.toString());
+    }
+
+    @Test
+    public void testNaNUnderlyingDouble() {
+        assertTrue(Double.isNaN(RealNaN.FLOAT_NAN.value));
+        assertTrue(Double.isNaN(RealNaN.DOUBLE_NAN.value));
+    }
+
+    //  RealInfinity tests
+
+    @Test
+    public void testInfinityCreation() {
+        RealInfinity posFloatInf = RealInfinity.get(true, FpSort.FLOAT);
+        RealInfinity negFloatInf = RealInfinity.get(false, FpSort.FLOAT);
+        RealInfinity posDoubleInf = RealInfinity.get(true, FpSort.DOUBLE);
+        RealInfinity negDoubleInf = RealInfinity.get(false, FpSort.DOUBLE);
+
+        assertNotNull(posFloatInf);
+        assertNotNull(negFloatInf);
+        assertNotNull(posDoubleInf);
+        assertNotNull(negDoubleInf);
+    }
+
+    @Test
+    public void testInfinityEquality() {
+        RealInfinity inf1 = RealInfinity.get(true, FpSort.FLOAT);
+        RealInfinity inf2 = RealInfinity.get(true, FpSort.FLOAT);
+        RealInfinity inf3 = RealInfinity.get(false, FpSort.FLOAT);
+        RealInfinity inf4 = RealInfinity.get(true, FpSort.DOUBLE);
+
+        assertEquals(inf1, inf2);
+        assertEquals(inf1.hashCode(), inf2.hashCode());
+        assertNotEquals(inf1, inf3);
+        assertNotEquals(inf1, inf4);
+    }
+
+    @Test
+    public void testInfinitySign() {
+        assertTrue(RealInfinity.get(true, FpSort.FLOAT).isPositive());
+        assertFalse(RealInfinity.get(false, FpSort.FLOAT).isPositive());
+    }
+
+    @Test
+    public void testInfinityToString() {
+        assertEquals("Float+Inf", RealInfinity.get(true, FpSort.FLOAT).toString());
+        assertEquals("Float-Inf", RealInfinity.get(false, FpSort.FLOAT).toString());
+        assertEquals("Double+Inf", RealInfinity.get(true, FpSort.DOUBLE).toString());
+        assertEquals("Double-Inf", RealInfinity.get(false, FpSort.DOUBLE).toString());
+    }
+
+    @Test
+    public void testInfinityUnderlyingDouble() {
+        RealInfinity posFloatInf = RealInfinity.get(true, FpSort.FLOAT);
+        RealInfinity negFloatInf = RealInfinity.get(false, FpSort.FLOAT);
+        RealInfinity posDoubleInf = RealInfinity.get(true, FpSort.DOUBLE);
+        RealInfinity negDoubleInf = RealInfinity.get(false, FpSort.DOUBLE);
+
+        assertEquals(Double.POSITIVE_INFINITY, posFloatInf.value, 0.0);
+        assertEquals(Double.NEGATIVE_INFINITY, negFloatInf.value, 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, posDoubleInf.value, 0.0);
+        assertEquals(Double.NEGATIVE_INFINITY, negDoubleInf.value, 0.0);
+    }
+
+    // RealZero tests
+
+    @Test
+    public void testZeroCreation() {
+        RealZero posFloatZero = RealZero.get(true, FpSort.FLOAT);
+        RealZero negFloatZero = RealZero.get(false, FpSort.FLOAT);
+        RealZero posDoubleZero = RealZero.get(true, FpSort.DOUBLE);
+        RealZero negDoubleZero = RealZero.get(false, FpSort.DOUBLE);
+
+        assertNotNull(posFloatZero);
+        assertNotNull(negFloatZero);
+        assertNotNull(posDoubleZero);
+        assertNotNull(negDoubleZero);
+    }
+
+    @Test
+    public void testZeroEquality() {
+        RealZero zero1 = RealZero.get(true, FpSort.FLOAT);
+        RealZero zero2 = RealZero.get(true, FpSort.FLOAT);
+        RealZero zero3 = RealZero.get(false, FpSort.FLOAT);
+        RealZero zero4 = RealZero.get(true, FpSort.DOUBLE);
+
+        assertEquals(zero1, zero2);
+        assertEquals(zero1.hashCode(), zero2.hashCode());
+        assertNotEquals(zero1, zero3);
+        assertNotEquals(zero1, zero4);
+    }
+
+    @Test
+    public void testZeroSign() {
+        assertTrue(RealZero.get(true, FpSort.FLOAT).isPositive());
+        assertFalse(RealZero.get(false, FpSort.FLOAT).isPositive());
+    }
+
+    @Test
+    public void testZeroToString() {
+        assertEquals("Float+Zero", RealZero.get(true, FpSort.FLOAT).toString());
+        assertEquals("Float-Zero", RealZero.get(false, FpSort.FLOAT).toString());
+        assertEquals("Double+Zero", RealZero.get(true, FpSort.DOUBLE).toString());
+        assertEquals("Double-Zero", RealZero.get(false, FpSort.DOUBLE).toString());
+    }
+
+    @Test
+    public void testZeroUnderlyingDouble() {
+        RealZero posFloatZero = RealZero.get(true, FpSort.FLOAT);
+        RealZero negFloatZero = RealZero.get(false, FpSort.FLOAT);
+        RealZero posDoubleZero = RealZero.get(true, FpSort.DOUBLE);
+        RealZero negDoubleZero = RealZero.get(false, FpSort.DOUBLE);
+
+        assertEquals(0.0, posFloatZero.value, 0.0);
+        assertEquals(-0.0, negFloatZero.value, 0.0);
+        assertEquals(0.0, posDoubleZero.value, 0.0);
+        assertEquals(-0.0, negDoubleZero.value, 0.0);
+
+        // Verify bit pattern for negative zero
+        assertEquals(0x8000000000000000L, Double.doubleToLongBits(negFloatZero.value));
+    }
+
+    // Factory tests
+
+    @Test
+    public void testFactoryNaN() {
+        assertSame(RealNaN.FLOAT_NAN, SpecialValueFactory.createNaN(false));
+        assertSame(RealNaN.DOUBLE_NAN, SpecialValueFactory.createNaN(true));
+    }
+
+    @Test
+    public void testFactoryInfinity() {
+        RealInfinity inf1 = SpecialValueFactory.createInfinity(true, false);
+        RealInfinity inf2 = SpecialValueFactory.createInfinity(false, true);
+        assertTrue(inf1.isPositive());
+        assertEquals(FpSort.FLOAT, inf1.getSort());
+        assertFalse(inf2.isPositive());
+        assertEquals(FpSort.DOUBLE, inf2.getSort());
+    }
+
+    @Test
+    public void testFactoryZero() {
+        RealZero zero1 = SpecialValueFactory.createZero(true, false);
+        RealZero zero2 = SpecialValueFactory.createZero(false, true);
+        assertTrue(zero1.isPositive());
+        assertEquals(FpSort.FLOAT, zero1.getSort());
+        assertFalse(zero2.isPositive());
+        assertEquals(FpSort.DOUBLE, zero2.getSort());
+    }
+
+    // Visitor tests
+
+    // Simple visitor that counts visits to RealConstant
+    private static class CountingVisitor extends ConstraintExpressionVisitor {
+        int count = 0;
+
+        @Override
+        public void postVisit(RealConstant realConstant) {
+            count++;
+        }
+    }
+
+    @Test
+    public void testAcceptNaN() {
+        CountingVisitor visitor = new CountingVisitor();
+        RealNaN.FLOAT_NAN.accept(visitor);
+        assertEquals(1, visitor.count);
+    }
+
+    @Test
+    public void testAcceptInfinity() {
+        CountingVisitor visitor = new CountingVisitor();
+        RealInfinity.get(true, FpSort.FLOAT).accept(visitor);
+        assertEquals(1, visitor.count);
+    }
+
+    @Test
+    public void testAcceptZero() {
+        CountingVisitor visitor = new CountingVisitor();
+        RealZero.get(true, FpSort.FLOAT).accept(visitor);
+        assertEquals(1, visitor.count);
+    }
+}


### PR DESCRIPTION
## Issue
#27
## Rational
This PR introduces symbolic representations for the IEEE‑754 special values: NaN, positive/negative infinity, and signed zero. These constants are essential for correctly modelling floating‑point exceptional behaviour such as division by zero, overflow, and underflow.
## Implementation
- Add FpSort enum to distinguish float/double precision.
- Introduce RealSpecialConstant base class holding precision.
- Implement RealNaN, RealInfinity, RealZero with:
    * Precision awareness (FpSort)
    * Sign flags for infinity and zero
    * Bit‑level negative zero storage to preserve sign
    * Structural equality for NaN (all NaN of same sort equal)
- Provide SpecialValueFactory for easy creation in bytecode.
- Update numeric visitor integration via accept(ConstraintExpressionVisitor).

## How was this tested?
Added a comprehensive list of unit tests covering creation, equality, string representation, underlying values, factory, and visitor dispatch.
All tests pass. This change lays the foundation for correct modelling of floating‑point exceptional behaviour in subsequent issues.